### PR TITLE
Vouch cookie fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,42 @@ Once the containers are up connect to https://127.0.0.1:8443/ui to interact with
     - API Server
     - Vouch Proxy
     - Postgres 
+  
+## Testing components 
+
+If you don't want to use docker compose, you can start individual Dockers (for postgres and api server) as follows to help test:
+```
+$ docker run -d --name pgsql -e POSTGRES_PASSWORD=uiservice -e PGDATA=/var/lib/postgresql/data/pgdata -v /some/path/to/persistent/pgsqldata/:/var/lib/postgresql/data -p 5432:5432 postgres
+$ docker run -d --name uis -e POSTGRES_HOST=localhost -e POSTGRES_PORT=5432 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=uiservice -e SWAGGER_HOST=127.0.0.1 -p 5000:5000 uis
+```
+
+Note that API server looks for environment variable `UISERVICE_MOCK` to be set to true to load tables with mock data automatically.
+
+### Testing the database
+
+Start the database docker as shown above. You can then get to `bash` inside of it and run the Posgres client tool 
+(you can also do it from outside the container if you have the client installed). Note that since Postgres is started
+as listening on a port, the client tool won't connect over a socket even from inside the container.
+
+```
+$ psql -h localhost -p 5432 -U postgres
+```
+Some helpful Postgres commamds: 
+
+- listing schema:
+```
+select table_name, column_name, data_type from information_schema.columns where table_name = 'fabric_papers';
+```
+- listing and changing databases
+```
+\l list databases
+\c <db name>
+```
+- describing tables in a database
+```
+\dt describe tables
+```
+
 
 # Deployment
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ proper secrets, certs etc. You must edit the following files to support a produc
 
 To configure Vouch Proxy, copy [vouch/config_template](vouch/config_template) to `vouch/config`, edit at least the 
 following parameters:
-- `vouch/publicAccess` set to `false` (unless testing)
+- `vouch/publicAccess` set to `true` (UIS has to allow unauthenticated access in some cases)
 - `jwt/secret` must be changed - if using in production, it likely needs to be the same as on all other services,
 e.g. Project Registry
 - `cookie/domain` must be set to appropriate domain (127.0.0.1 only works for testing, set it to the domain where the

--- a/docker-compose-vouch-proxy-local.yml
+++ b/docker-compose-vouch-proxy-local.yml
@@ -14,7 +14,7 @@ services:
 #      - frontend
     restart: on-failure
 
-  api-server:
+  uis-server:
     build:
       context: ./
       dockerfile: Dockerfile

--- a/server/README.md
+++ b/server/README.md
@@ -8,7 +8,7 @@ is an example of building a swagger-enabled Flask server.
 This example uses the [Connexion](https://github.com/zalando/connexion) library on top of Flask.
 
 ## Requirements
-Python 3.5.2+
+Python 3.9.0+
 
 ## Usage
 To run the server, please execute the following from the root directory:
@@ -23,12 +23,7 @@ http://localhost:8080/ui/
 Your Swagger definition lives here:
 
 ```
-http://localhost:8080//swagger.json
-```
-To launch the integration tests, use tox:
-```
-sudo pip install tox
-tox
+http://localhost:8080/swagger.json
 ```
 
 ## Running with Docker
@@ -43,37 +38,3 @@ docker build -t swagger_server .
 docker run -p 8080:8080 swagger_server
 ```
 
-## Testing components 
-
-If you don't want to use docker compose, you can start individual Dockers (for postgres and api server) as follows to help test:
-```
-$ docker run -d --name pgsql -e POSTGRES_PASSWORD=uiservice -e PGDATA=/var/lib/postgresql/data/pgdata -v /some/path/to/persistent/pgsqldata/:/var/lib/postgresql/data -p 5432:5432 postgres
-$ docker run -d --name uis -e POSTGRES_HOST=localhost -e POSTGRES_PORT=5432 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=uiservice -e SWAGGER_HOST=127.0.0.1 -p 5000:5000 uis
-```
-
-Note that API server looks for environment variable `UISERVICE_MOCK` to be set to true to load tables with mock data automatically.
-
-### Testing the database
-
-Start the database docker as shown above. You can then get to `bash` inside of it and run the Posgres client tool 
-(you can also do it from outside the container if you have the client installed). Note that since Postgres is started
-as listening on a port, the client tool won't connect over a socket even from inside the container.
-
-```
-$ psql -h localhost -p 5432 -U postgres
-```
-Some helpful Postgres commamds: 
-
-- listing schema:
-```
-select table_name, column_name, data_type from information_schema.columns where table_name = 'fabric_papers';
-```
-- listing and changing databases
-```
-\l list databases
-\c <db name>
-```
-- describing tables in a database
-```
-\dt describe tables
-```

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -10,14 +10,14 @@ colorama==0.4.4
 connexion==2.7.0
 cryptography==3.3.2
 distlib==0.3.1
-fabric-fss-utils==0.12
+fabric-fss-utils==0.13
 filelock==3.0.12
 Flask==1.1.2
 idna==2.10
 importlib-metadata==3.7.3
 inflection==0.5.1
 itsdangerous==1.1.0
-Jinja2==2.11.2
+Jinja2==2.11.3
 jsonschema==2.6.0
 keyring==21.5.0
 ldap3==2.8.1

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -10,11 +10,11 @@ colorama==0.4.4
 connexion==2.7.0
 cryptography==3.3.2
 distlib==0.3.1
-fabric-fss-utils==0.6
+fabric-fss-utils==0.12
 filelock==3.0.12
 Flask==1.1.2
 idna==2.10
-importlib-metadata==3.1.1
+importlib-metadata==3.7.3
 inflection==0.5.1
 itsdangerous==1.1.0
 Jinja2==2.11.2
@@ -31,7 +31,7 @@ py==1.9.0
 pyasn1==0.4.8
 pycodestyle==2.6.0
 pycparser==2.20
-Pygments==2.7.3
+Pygments==2.7.4
 PyJWT==1.7.1
 pyparsing==2.4.7
 python-dateutil==2.6.0
@@ -40,12 +40,12 @@ PyYAML==5.3.1
 requests==2.25.1
 requests-toolbelt==0.9.1
 rfc3986==1.4.0
-six==1.15.0
 SQLAlchemy==1.3.20
 swagger-ui-bundle==0.0.8
 toml==0.10.2
+tox==3.23.0
 tqdm==4.54.1
-urllib3==1.26.2
+urllib3==1.26.4
 uWSGI==2.0.19.1
 virtualenv==20.3.1
 webencodings==0.5.1

--- a/server/swagger_server/response_code/people_controller.py
+++ b/server/swagger_server/response_code/people_controller.py
@@ -28,7 +28,7 @@ from flask import request
 from sqlalchemy import or_, and_
 
 from http import HTTPStatus
-from fss_utils.http_errors import HTTPErrorTuple
+from fss_utils.http_errors import cors_response
 
 from swagger_server.database import Session
 from swagger_server.database.models import FabricPerson
@@ -46,29 +46,29 @@ def people_get(person_name=None):  # noqa: E501
     :rtype: List[PeopleShort]
     """
     if not utils.any_authenticated_user(request.headers):
-        return HTTPErrorTuple(HTTPStatus.UNAUTHORIZED,
-                              "User not authenticated").astuple()
+        return cors_response(HTTPStatus.UNAUTHORIZED,
+                             xerror="User not authenticated")
 
     person_name = str(person_name).strip()
 
     # can't let them query by fewer than 5 characters
     if not person_name or len(person_name) < QUERY_CHARACTER_MIN:
         log.error(f'Bad /people request - insufficient information for search')
-        return HTTPErrorTuple(HTTPStatus.BAD_REQUEST,
-                              'Insufficient number of characters or bad name').astuple()
+        return cors_response(HTTPStatus.BAD_REQUEST,
+                             xerror='Insufficient number of characters or bad name')
 
     session = Session()
     try:
         status, active_flag = utils.check_user_active(session, request.headers)
         if status != 200:
             log.error(f'Problem {status} contacting COmanage for active user check in /people')
-            return HTTPErrorTuple(HTTPStatus.INTERNAL_SERVER_ERROR,
-                                  f'Error {status} contacting COmanage').astuple()
+            return cors_response(HTTPStatus.INTERNAL_SERVER_ERROR,
+                                 xerror=f'Error {status} contacting COmanage')
 
         if not active_flag:
             log.warn(f'User is not an active user in /people')
-            return HTTPErrorTuple(HTTPStatus.FORBIDDEN,
-                                  'User is not an active user').astuple()
+            return cors_response(HTTPStatus.FORBIDDEN,
+                                 xerror='User is not an active user')
 
         # query by name and email
         query = session.query(FabricPerson).\
@@ -79,7 +79,8 @@ def people_get(person_name=None):  # noqa: E501
 
         if len(query_result) == 0:
             log.warn(f'No matching users found for {person_name} in /people')
-            return HTTPErrorTuple(HTTPStatus.NOT_FOUND, 'No matches for people found.').astuple()
+            return cors_response(HTTPStatus.NOT_FOUND,
+                                 xerror='No matches for people found.')
 
         response = []
         for person in query_result:
@@ -98,8 +99,8 @@ def people_whoami_get():  # noqa: E501
     :rtype: PeopleLong
     """
     if not utils.any_authenticated_user(request.headers):
-        return HTTPErrorTuple(HTTPStatus.UNAUTHORIZED,
-                              'User not authenticated').astuple()
+        return cors_response(HTTPStatus.UNAUTHORIZED,
+                             xerror='User not authenticated')
 
     # trust the token, get claim sub from it
     # if token is absent, this helps portal figure out if user is not authenticated
@@ -107,8 +108,8 @@ def people_whoami_get():  # noqa: E501
     oidc_claim_sub = utils.extract_oidc_claim(request.headers)
     if oidc_claim_sub is None:
         log.warn(f'No OIDC Claim Sub found in /whoami')
-        return HTTPErrorTuple(HTTPStatus.FORBIDDEN,
-                              "No OIDC Claim Sub found or ID token missing").astuple()
+        return cors_response(HTTPStatus.FORBIDDEN,
+                             xerror="No OIDC Claim Sub found or ID token missing")
 
     session = Session()
     try:
@@ -124,21 +125,21 @@ def people_whoami_get():  # noqa: E501
             query_result = query.all()
             if len(query_result) != 1:
                 log.error('Unable to insert new user into UIS database in /whoami')
-                return HTTPErrorTuple(HTTPStatus.INTERNAL_SERVER_ERROR,
-                                      'Insertion in UIS database failed').astuple()
+                return cors_response(HTTPStatus.INTERNAL_SERVER_ERROR,
+                                     xerror='Insertion in UIS database failed')
         else:
             if len(query_result) > 1:
                 log.warn(f'Duplicate ODIC claim found in the database {str(oidc_claim_sub)} in /whoami')
-                return HTTPErrorTuple(HTTPStatus.INTERNAL_SERVER_ERROR,
-                                      'Duplicate OIDC Claim Found: {0}'.format(str(oidc_claim_sub))).astuple()
+                return cors_response(HTTPStatus.INTERNAL_SERVER_ERROR,
+                                     xerror='Duplicate OIDC Claim Found: {0}'.format(str(oidc_claim_sub)))
 
         person = query_result[0]
         # check with COmanage they are an active user
         status, active_flag, co_person_id = utils.comanage_check_active_person(person)
         if status != 200:
             log.error(f'Error {status} contacting comanage in /whoami')
-            return HTTPErrorTuple(HTTPStatus.INTERNAL_SERVER_ERROR,
-                                  f'Error {status} contacting COmanage').astuple()
+            return cors_response(HTTPStatus.INTERNAL_SERVER_ERROR,
+                                 xerror=f'Error {status} contacting COmanage')
 
         commit_needed = False
         if co_person_id is not None and \
@@ -149,8 +150,8 @@ def people_whoami_get():  # noqa: E501
 
         if not active_flag:
             log.warn(f'User co_person_id={co_person_id} is not an active user in /people/whoami')
-            return HTTPErrorTuple(HTTPStatus.FORBIDDEN,
-                                  'User not an active user').astuple()
+            return cors_response(HTTPStatus.FORBIDDEN,
+                                 xerror='User not an active user')
 
         # sometimes we don't get a name from the token
         # so get it from COmanage
@@ -176,14 +177,14 @@ def people_uuid_get(uuid):  # noqa: E501
     :rtype: PeopleLong
     """
     if not utils.any_authenticated_user(request.headers):
-        return "Unauthorized", 401, \
-               {'X-Error': 'User not authenticated'}
+        return cors_response(HTTPStatus.UNAUTHORIZED,
+                             xerror='User not authenticated')
 
     uuid = str(uuid).strip()
     if not utils.validate_uuid_by_oidc_claim(request.headers, uuid):
         log.error(f'OIDC Claim Sub doesnt match uuid {uuid} in /people/uuid')
-        return HTTPErrorTuple(HTTPStatus.FORBIDDEN,
-                              "OIDC Claim Sub doesnt match UUID").astuple()
+        return cors_response(HTTPStatus.FORBIDDEN,
+                             xerror="OIDC Claim Sub doesnt match UUID")
 
     session = Session()
     query = session.query(FabricPerson).filter(FabricPerson.uuid == uuid)
@@ -192,13 +193,13 @@ def people_uuid_get(uuid):  # noqa: E501
 
     if len(query_result) == 0:
         log.warn(f'Person UUID {uuid} not found in /people/uuid')
-        return HTTPErrorTuple(HTTPStatus.NOT_FOUND,
-                              'Person UUID not found: {0}'.format(str(uuid))).astuple()
+        return cors_response(HTTPStatus.NOT_FOUND,
+                             xerror='Person UUID not found: {0}'.format(str(uuid)))
 
     if len(query_result) > 1:
         log.warn(f'Duplicate UUID {uuid} found in /people/uuid')
-        return HTTPErrorTuple(HTTPStatus.INTERNAL_SERVER_ERROR,
-                              'Duplicate UUID Found: {0}'.format(str(uuid))).astuple()
+        return cors_response(HTTPStatus.INTERNAL_SERVER_ERROR,
+                             xerror='Duplicate UUID Found: {0}'.format(str(uuid)))
 
     person = query_result[0]
 
@@ -210,8 +211,8 @@ def uuid_oidc_claim_sub_get(oidc_claim_sub):
     get the UUID mapped to this claim sub (open to any valid user)
     """
     if not utils.any_authenticated_user(request.headers):
-        return HTTPErrorTuple(HTTPStatus.UNAUTHORIZED,
-                              'User not authenticated').astuple()
+        return cors_response(HTTPStatus.UNAUTHORIZED,
+                             xerror='User not authenticated')
 
     oidc_claim_sub = str(oidc_claim_sub).strip()
 
@@ -219,26 +220,26 @@ def uuid_oidc_claim_sub_get(oidc_claim_sub):
     status, active_flag = utils.check_user_active(session, request.headers)
     if status != 200:
         log.error(f'Error {status} contacting COmanage in /uuid/oidc_claim_sub')
-        return HTTPErrorTuple(HTTPStatus.INTERNAL_SERVER_ERROR,
-                              f'Error {status} contacting COmanage').astuple()
+        return cors_response(HTTPStatus.INTERNAL_SERVER_ERROR,
+                             xerror=f'Error {status} contacting COmanage')
 
     if not active_flag:
         log.warn(f'User is not an active user in /uuid/oidc_claim_sub')
-        return HTTPErrorTuple(HTTPStatus.FORBIDDEN,
-                              'User not an active user').astuple()
+        return cors_response(HTTPStatus.FORBIDDEN,
+                             xerror='User not an active user')
 
     query = session.query(FabricPerson).filter(FabricPerson.oidc_claim_sub == oidc_claim_sub)
     query_result = query.all()
 
     if len(query_result) == 0:
         log.warn(f'Person with OIDC Claim sub {str(oidc_claim_sub)} in /uuid/oidc_claim_sub not found in database')
-        return HTTPErrorTuple(HTTPStatus.NOT_FOUND,
-                              'Person with OIDC claim sub not found: {0}'.format(oidc_claim_sub)).astuple()
+        return cors_response(HTTPStatus.NOT_FOUND,
+                             xerror='Person with OIDC claim sub not found: {0}'.format(oidc_claim_sub))
     else:
         if len(query_result) > 1:
             log.warn(f'Duplicate OIDC Claim {str(oidc_claim_sub)} found in the database in /uuid/oidc_claim_sub')
-            return HTTPErrorTuple(HTTPStatus.INTERNAL_SERVER_ERROR,
-                                  'Duplicate OIDC Claim Found: {0}'.format(oidc_claim_sub)).astuple()
+            return cors_response(HTTPStatus.INTERNAL_SERVER_ERROR,
+                                 xerror='Duplicate OIDC Claim Found: {0}'.format(oidc_claim_sub))
 
     person = query_result[0]
     return person.uuid

--- a/server/swagger_server/response_code/people_controller.py
+++ b/server/swagger_server/response_code/people_controller.py
@@ -90,11 +90,13 @@ def people_whoami_get():  # noqa: E501
     :rtype: PeopleLong
     """
     # trust the token, get claim sub from it
+    # if token is absent, this helps portal figure out if user is not authenticated
+    # so don't panic, just return 'Unauthorized'
     oidc_claim_sub = utils.extract_oidc_claim(request.headers)
     if oidc_claim_sub is None:
-        log.error(f'No OIDC Claim Sub found or ID token missing in /whoami')
-        return 'No OIDC Claim Sub found or ID token missing', 404, \
-               {'X-Error': 'OIDC Claim Not Found'}
+        log.warn(f'No OIDC Claim Sub found or ID token missing in /whoami')
+        return 'User not authorized', 401, \
+               {'X-Error': 'Unauthorized'}
 
     session = Session()
     try:
@@ -134,8 +136,8 @@ def people_whoami_get():  # noqa: E501
 
         if not active_flag:
             log.warn(f'User co_person_id={co_person_id} is not an active user in /whoami')
-            return 'User not an active user', 401, \
-                   {'X-Error': 'Unauthorized'}
+            return 'User not an active user', 403, \
+                   {'X-Error': 'Forbidden'}
 
         # sometimes we don't get a name from the token
         # so get it from COmanage

--- a/server/swagger_server/response_code/people_controller.py
+++ b/server/swagger_server/response_code/people_controller.py
@@ -27,6 +27,9 @@
 from flask import request
 from sqlalchemy import or_, and_
 
+from http import HTTPStatus
+from fss_utils.http_errors import HTTPErrorTuple
+
 from swagger_server.database import Session
 from swagger_server.database.models import FabricPerson
 from swagger_server.models.people_long import PeopleLong  # noqa: E501
@@ -42,25 +45,30 @@ def people_get(person_name=None):  # noqa: E501
     :type person_name: str
     :rtype: List[PeopleShort]
     """
+    if not utils.any_authenticated_user(request.headers):
+        return HTTPErrorTuple(HTTPStatus.UNAUTHORIZED,
+                              "User not authenticated").astuple()
+
     person_name = str(person_name).strip()
 
     # can't let them query by fewer than 5 characters
     if not person_name or len(person_name) < QUERY_CHARACTER_MIN:
         log.error(f'Bad /people request - insufficient information for search')
-        return "Must provide more information", 400, \
-               {'X-Error': 'Bad request'}
+        return HTTPErrorTuple(HTTPStatus.BAD_REQUEST,
+                              'Insufficient number of characters or bad name').astuple()
 
     session = Session()
     try:
         status, active_flag = utils.check_user_active(session, request.headers)
         if status != 200:
             log.error(f'Problem {status} contacting COmanage for active user check in /people')
-            return f'Error {status} contacting COmanage', 500, \
-                   {'X-Error': 'COmanage problem'}
+            return HTTPErrorTuple(HTTPStatus.INTERNAL_SERVER_ERROR,
+                                  f'Error {status} contacting COmanage').astuple()
+
         if not active_flag:
             log.warn(f'User is not an active user in /people')
-            return 'User not an active user', 401, \
-                   {'X-Error': 'Unauthorized'}
+            return HTTPErrorTuple(HTTPStatus.FORBIDDEN,
+                                  'User is not an active user').astuple()
 
         # query by name and email
         query = session.query(FabricPerson).\
@@ -71,7 +79,7 @@ def people_get(person_name=None):  # noqa: E501
 
         if len(query_result) == 0:
             log.warn(f'No matching users found for {person_name} in /people')
-            return 'No matches for people found.', 404, {'X-Error': 'People Not Found'}
+            return HTTPErrorTuple(HTTPStatus.NOT_FOUND, 'No matches for people found.').astuple()
 
         response = []
         for person in query_result:
@@ -89,14 +97,18 @@ def people_whoami_get():  # noqa: E501
     If a person doesn't exist, it gets created.
     :rtype: PeopleLong
     """
+    if not utils.any_authenticated_user(request.headers):
+        return HTTPErrorTuple(HTTPStatus.UNAUTHORIZED,
+                              'User not authenticated').astuple()
+
     # trust the token, get claim sub from it
     # if token is absent, this helps portal figure out if user is not authenticated
     # so don't panic, just return 'Unauthorized'
     oidc_claim_sub = utils.extract_oidc_claim(request.headers)
     if oidc_claim_sub is None:
-        log.warn(f'No OIDC Claim Sub found or ID token missing in /whoami')
-        return 'User not authorized', 401, \
-               {'X-Error': 'Unauthorized'}
+        log.warn(f'No OIDC Claim Sub found in /whoami')
+        return HTTPErrorTuple(HTTPStatus.FORBIDDEN,
+                              "No OIDC Claim Sub found or ID token missing").astuple()
 
     session = Session()
     try:
@@ -112,21 +124,22 @@ def people_whoami_get():  # noqa: E501
             query_result = query.all()
             if len(query_result) != 1:
                 log.error('Unable to insert new user into UIS database in /whoami')
-                return 'Insertion in UIS database failed', 500, \
-                       {'X-Error': 'Internal server error'}
+                return HTTPErrorTuple(HTTPStatus.INTERNAL_SERVER_ERROR,
+                                      'Insertion in UIS database failed').astuple()
         else:
             if len(query_result) > 1:
                 log.warn(f'Duplicate ODIC claim found in the database {str(oidc_claim_sub)} in /whoami')
-                return 'Duplicate OIDC Claim Found: {0}'.format(str(oidc_claim_sub)), 500, \
-                       {'X-Error': 'Duplicate person found'}
+                return HTTPErrorTuple(HTTPStatus.INTERNAL_SERVER_ERROR,
+                                      'Duplicate OIDC Claim Found: {0}'.format(str(oidc_claim_sub))).astuple()
 
         person = query_result[0]
         # check with COmanage they are an active user
         status, active_flag, co_person_id = utils.comanage_check_active_person(person)
         if status != 200:
             log.error(f'Error {status} contacting comanage in /whoami')
-            return f'Error {status} contacting COmanage', 500, \
-                       {'X-Error': 'COmanage problem'}
+            return HTTPErrorTuple(HTTPStatus.INTERNAL_SERVER_ERROR,
+                                  f'Error {status} contacting COmanage').astuple()
+
         commit_needed = False
         if co_person_id is not None and \
                 (person.co_person_id is None or len(person.co_person_id) == 0):
@@ -135,9 +148,9 @@ def people_whoami_get():  # noqa: E501
             commit_needed = True
 
         if not active_flag:
-            log.warn(f'User co_person_id={co_person_id} is not an active user in /whoami')
-            return 'User not an active user', 403, \
-                   {'X-Error': 'Forbidden'}
+            log.warn(f'User co_person_id={co_person_id} is not an active user in /people/whoami')
+            return HTTPErrorTuple(HTTPStatus.FORBIDDEN,
+                                  'User not an active user').astuple()
 
         # sometimes we don't get a name from the token
         # so get it from COmanage
@@ -162,11 +175,15 @@ def people_uuid_get(uuid):  # noqa: E501
     :type uuid: str
     :rtype: PeopleLong
     """
+    if not utils.any_authenticated_user(request.headers):
+        return "Unauthorized", 401, \
+               {'X-Error': 'User not authenticated'}
+
     uuid = str(uuid).strip()
     if not utils.validate_uuid_by_oidc_claim(request.headers, uuid):
         log.error(f'OIDC Claim Sub doesnt match uuid {uuid} in /people/uuid')
-        return "OIDC Claim Sub doesnt match UUID", 401, \
-               {'X-Error': 'Authorization information is missing or invalid'}
+        return HTTPErrorTuple(HTTPStatus.FORBIDDEN,
+                              "OIDC Claim Sub doesnt match UUID").astuple()
 
     session = Session()
     query = session.query(FabricPerson).filter(FabricPerson.uuid == uuid)
@@ -175,13 +192,13 @@ def people_uuid_get(uuid):  # noqa: E501
 
     if len(query_result) == 0:
         log.warn(f'Person UUID {uuid} not found in /people/uuid')
-        return 'Person UUID not found: {0}'.format(str(uuid)), 404, \
-               {'X-Error': 'People Not Found'}
+        return HTTPErrorTuple(HTTPStatus.NOT_FOUND,
+                              'Person UUID not found: {0}'.format(str(uuid))).astuple()
 
     if len(query_result) > 1:
         log.warn(f'Duplicate UUID {uuid} found in /people/uuid')
-        return 'Duplicate UUID Found: {0}'.format(str(uuid)), 500, \
-               {'X-Error': 'Duplicate person found'}
+        return HTTPErrorTuple(HTTPStatus.INTERNAL_SERVER_ERROR,
+                              'Duplicate UUID Found: {0}'.format(str(uuid))).astuple()
 
     person = query_result[0]
 
@@ -192,31 +209,36 @@ def uuid_oidc_claim_sub_get(oidc_claim_sub):
     """
     get the UUID mapped to this claim sub (open to any valid user)
     """
+    if not utils.any_authenticated_user(request.headers):
+        return HTTPErrorTuple(HTTPStatus.UNAUTHORIZED,
+                              'User not authenticated').astuple()
+
     oidc_claim_sub = str(oidc_claim_sub).strip()
 
     session = Session()
     status, active_flag = utils.check_user_active(session, request.headers)
     if status != 200:
         log.error(f'Error {status} contacting COmanage in /uuid/oidc_claim_sub')
-        return f'Error {status} contacting COmanage', 500, \
-               {'X-Error': 'COmanage problem'}
+        return HTTPErrorTuple(HTTPStatus.INTERNAL_SERVER_ERROR,
+                              f'Error {status} contacting COmanage').astuple()
+
     if not active_flag:
         log.warn(f'User is not an active user in /uuid/oidc_claim_sub')
-        return 'User not an active user', 401, \
-               {'X-Error': 'Unauthorized'}
+        return HTTPErrorTuple(HTTPStatus.FORBIDDEN,
+                              'User not an active user').astuple()
 
     query = session.query(FabricPerson).filter(FabricPerson.oidc_claim_sub == oidc_claim_sub)
     query_result = query.all()
 
     if len(query_result) == 0:
         log.warn(f'Person with OIDC Claim sub {str(oidc_claim_sub)} in /uuid/oidc_claim_sub not found in database')
-        return 'Person with OIDC claim sub not found: {0}'.format(oidc_claim_sub), 404, \
-               {'X-Error': 'People Not Found'}
+        return HTTPErrorTuple(HTTPStatus.NOT_FOUND,
+                              'Person with OIDC claim sub not found: {0}'.format(oidc_claim_sub)).astuple()
     else:
         if len(query_result) > 1:
             log.warn(f'Duplicate OIDC Claim {str(oidc_claim_sub)} found in the database in /uuid/oidc_claim_sub')
-            return 'Duplicate OIDC Claim Found: {0}'.format(oidc_claim_sub), 500, \
-                   {'X-Error': 'Duplicate person found'}
+            return HTTPErrorTuple(HTTPStatus.INTERNAL_SERVER_ERROR,
+                                  'Duplicate OIDC Claim Found: {0}'.format(oidc_claim_sub)).astuple()
 
     person = query_result[0]
     return person.uuid

--- a/server/swagger_server/response_code/preferences_controller.py
+++ b/server/swagger_server/response_code/preferences_controller.py
@@ -28,7 +28,7 @@ import json
 from flask import request
 
 from http import HTTPStatus
-from fss_utils.http_errors import HTTPErrorTuple
+from fss_utils.http_errors import cors_response
 
 from swagger_server import log
 from swagger_server.database import Session
@@ -46,20 +46,20 @@ def preferences_preftype_uuid_get(preftype, uuid):  # noqa: E501
     Get user preferences as a string from the database
     """
     if not utils.any_authenticated_user(request.headers):
-        return HTTPErrorTuple(HTTPStatus.UNAUTHORIZED,
-                              'User not authenticated').astuple()
+        return cors_response(HTTPStatus.UNAUTHORIZED,
+                             xerror='User not authenticated')
 
     uuid = str(uuid).strip()
     if not utils.validate_uuid_by_oidc_claim(request.headers, uuid):
         log.error(f'OIDC Claim Sub doesnt match UUID {uuid} in /preferences/preftype/uuid')
-        return HTTPErrorTuple(HTTPStatus.FORBIDDEN,
-                              'OIDC Claim Sub doesnt match UUID').astuple()
+        return cors_response(HTTPStatus.FORBIDDEN,
+                             xerror='OIDC Claim Sub doesnt match UUID')
 
     # get preference by type
     if preftype not in PreferenceType.__members__.keys():
         log.warn(f'Inavlid preference type {str(preftype)} in /preferences/preftype/uuid')
-        return HTTPErrorTuple(HTTPStatus.BAD_REQUEST,
-                              'Invalid parameter').astuple()
+        return cors_response(HTTPStatus.BAD_REQUEST,
+                             xerror='Invalid parameter')
 
     session = Session()
     try:
@@ -69,24 +69,24 @@ def preferences_preftype_uuid_get(preftype, uuid):  # noqa: E501
 
         if len(query_result) == 0:
             log.warn(f'Person UUID {uuid} not found in /preferences/preftype/uuid')
-            return HTTPErrorTuple(HTTPStatus.NOT_FOUND,
-                                  'Person UUID not found: {0}'.format(uuid)).astuple()
+            return cors_response(HTTPStatus.NOT_FOUND,
+                                 xerror='Person UUID not found: {0}'.format(uuid))
 
         if len(query_result) > 1:
             log.warn(f"Duplicate UUID {uuid} detected in /preferences/preftype/uuid")
-            return HTTPErrorTuple(HTTPStatus.INTERNAL_SERVER_ERROR,
-                                  'Duplicate UUID Found: {0}'.format(uuid)).astuple()
+            return cors_response(HTTPStatus.INTERNAL_SERVER_ERROR,
+                                 xerror='Duplicate UUID Found: {0}'.format(uuid))
 
         if getattr(query_result[0], preftype) is not None:
             response = json.loads(getattr(query_result[0], preftype))
         else:
             log.warn(f'Preferences {preftype} not found for UUID {uuid}')
-            return HTTPErrorTuple(HTTPStatus.NO_CONTENT,
-                                  'Preference {0} for UUID {1} not found'.format(preftype, uuid)).astuple()
+            return cors_response(HTTPStatus.NO_CONTENT,
+                                 xerror='Preference {0} for UUID {1} not found'.format(preftype, uuid))
 
         if not isinstance(response, dict):
-            return HTTPErrorTuple(HTTPStatus.INTERNAL_SERVER_ERROR,
-                                  'DB return not a JSON dictionary as preference').astuple()
+            return cors_response(HTTPStatus.INTERNAL_SERVER_ERROR,
+                                 xerror='DB return not a JSON dictionary as preference')
 
         return response
     finally:
@@ -98,20 +98,20 @@ def preferences_preftype_uuid_put(uuid, preftype, preferences=None):  # noqa: E5
     Set user preferences as a string in the database
     """
     if not utils.any_authenticated_user(request.headers):
-        return HTTPErrorTuple(HTTPStatus.UNAUTHORIZED,
-                              'User not authenticated').astuple()
+        return cors_response(HTTPStatus.UNAUTHORIZED,
+                             xerror='User not authenticated')
 
     uuid = str(uuid).strip()
     if not utils.validate_uuid_by_oidc_claim(request.headers, uuid):
         log.error(f'OIDC Claim Sub doesnt match UUID {uuid} in /preferences/preftype/uuid')
-        return HTTPErrorTuple(HTTPStatus.FORBIDDEN,
-                              'OIDC Claim Sub doesnt match UUID').astuple()
+        return cors_response(HTTPStatus.FORBIDDEN,
+                             xerror='OIDC Claim Sub doesnt match UUID')
 
     # put preference by type
     if preftype not in PreferenceType.__members__.keys():
         log.warn(f'Inavlid preference type {str(preftype)} in /preferences/preftype/uuid')
-        return HTTPErrorTuple(HTTPStatus.BAD_REQUEST,
-                              'Invalid preference type {0}'.format(str(preftype))).astuple()
+        return cors_response(HTTPStatus.BAD_REQUEST,
+                             xerror='Invalid preference type {0}'.format(str(preftype)))
 
     session = Session()
     try:
@@ -121,13 +121,13 @@ def preferences_preftype_uuid_put(uuid, preftype, preferences=None):  # noqa: E5
 
         if len(query_result) == 0:
             log.warn(f'Person UUID {uuid} not found in /preferences/preftype/uuid')
-            return HTTPErrorTuple(HTTPStatus.NOT_FOUND,
-                                  'Person UUID Not Found: {0}'.format(uuid)).astuple()
+            return cors_response(HTTPStatus.NOT_FOUND,
+                                 xerror='Person UUID Not Found: {0}'.format(uuid))
 
         if len(query_result) > 1:
             log.warn(f'Duplicate UUID {uuid} not found in /preferences/preftype/uuid')
-            return HTTPErrorTuple(HTTPStatus.INTERNAL_SERVER_ERROR,
-                                  'Duplicate UUID Found: {0}'.format(uuid)).astuple()
+            return cors_response(HTTPStatus.INTERNAL_SERVER_ERROR,
+                                 xerror='Duplicate UUID Found: {0}'.format(uuid))
 
         person = query_result[0]
 
@@ -145,14 +145,14 @@ def preferences_uuid_get(uuid):  # noqa: E501
     Get all user preferences as a single object
     """
     if not utils.any_authenticated_user(request.headers):
-        return HTTPErrorTuple(HTTPStatus.UNAUTHORIZED,
-                              'User not authenticated').astuple()
+        return cors_response(HTTPStatus.UNAUTHORIZED,
+                             xerror='User not authenticated')
 
     uuid = str(uuid).strip()
     if not utils.validate_uuid_by_oidc_claim(request.headers, uuid):
         log.error(f'OIDC Claim Sub doesnt match UUID {uuid} in /preferences/uuid')
-        return HTTPErrorTuple(HTTPStatus.FORBIDDEN,
-                              'OIDC Claim Sub doesnt match UUID').astuple()
+        return cors_response(HTTPStatus.FORBIDDEN,
+                             xerror='OIDC Claim Sub doesnt match UUID')
 
     session = Session()
     try:
@@ -162,13 +162,13 @@ def preferences_uuid_get(uuid):  # noqa: E501
 
         if len(query_result) == 0:
             log.warn(f'Person UUID {uuid} not found in /preferences/uuid')
-            return HTTPErrorTuple(HTTPStatus.NOT_FOUND,
-                                  'Person UUID Not Found: {0}'.format(uuid)).astuple()
+            return cors_response(HTTPStatus.NOT_FOUND,
+                                 xerror='Person UUID Not Found: {0}'.format(uuid))
 
         if len(query_result) > 1:
             log.warn(f'Duplicate UUID {uuid} not found in /preferences/uuid')
-            return HTTPErrorTuple(HTTPStatus.INTERNAL_SERVER_ERROR,
-                                  'Duplicate UUID Found: {0}'.format(uuid)).astuple()
+            return cors_response(HTTPStatus.INTERNAL_SERVER_ERROR,
+                                 xerror='Duplicate UUID Found: {0}'.format(uuid))
 
         person = query_result[0]
 

--- a/server/swagger_server/response_code/publications_controller.py
+++ b/server/swagger_server/response_code/publications_controller.py
@@ -26,20 +26,36 @@
 
 from swagger_server.models.author_id import AuthorId
 from swagger_server.models.author_id_type import AuthorIdType
+from flask import request
 
-from .utils import dict_from_query
+from http import HTTPStatus
+from fss_utils.http_errors import HTTPErrorTuple
+
+import swagger_server.response_code.utils as utils
 
 
 def authorids_idtype_uuid_get(idtype, uuid):  # noqa: E501
+
+    if not utils.any_authenticated_user(request.headers):
+        return HTTPErrorTuple(HTTPStatus.UNAUTHORIZED,
+                              'User not authenticated').astuple()
 
     return 'Method unimplemented', 400, {'X-Error': 'Method unimplemented'}
 
 
 def authorids_idtype_uuid_put(idtype, uuid, idval):  # noqa: E501
 
+    if not utils.any_authenticated_user(request.headers):
+        return HTTPErrorTuple(HTTPStatus.UNAUTHORIZED,
+                              'User not authenticated').astuple()
+
     return 'Method unimplemented', 400, {'X-Error': 'Method unimplemented'}
 
 
 def authorids_uuid_get(uuid):  # noqa: E501
+
+    if not utils.any_authenticated_user(request.headers):
+        return HTTPErrorTuple(HTTPStatus.UNAUTHORIZED,
+                              'User not authenticated').astuple()
 
     return 'Method unimplemented', 400, {'X-Error': 'Method unimplemented'}

--- a/server/swagger_server/response_code/publications_controller.py
+++ b/server/swagger_server/response_code/publications_controller.py
@@ -29,7 +29,7 @@ from swagger_server.models.author_id_type import AuthorIdType
 from flask import request
 
 from http import HTTPStatus
-from fss_utils.http_errors import HTTPErrorTuple
+from fss_utils.http_errors import cors_response
 
 import swagger_server.response_code.utils as utils
 
@@ -37,8 +37,8 @@ import swagger_server.response_code.utils as utils
 def authorids_idtype_uuid_get(idtype, uuid):  # noqa: E501
 
     if not utils.any_authenticated_user(request.headers):
-        return HTTPErrorTuple(HTTPStatus.UNAUTHORIZED,
-                              'User not authenticated').astuple()
+        return cors_response(HTTPStatus.UNAUTHORIZED,
+                             xerror='User not authenticated')
 
     return 'Method unimplemented', 400, {'X-Error': 'Method unimplemented'}
 
@@ -46,8 +46,8 @@ def authorids_idtype_uuid_get(idtype, uuid):  # noqa: E501
 def authorids_idtype_uuid_put(idtype, uuid, idval):  # noqa: E501
 
     if not utils.any_authenticated_user(request.headers):
-        return HTTPErrorTuple(HTTPStatus.UNAUTHORIZED,
-                              'User not authenticated').astuple()
+        return cors_response(HTTPStatus.UNAUTHORIZED,
+                             xerror='User not authenticated')
 
     return 'Method unimplemented', 400, {'X-Error': 'Method unimplemented'}
 
@@ -55,7 +55,7 @@ def authorids_idtype_uuid_put(idtype, uuid, idval):  # noqa: E501
 def authorids_uuid_get(uuid):  # noqa: E501
 
     if not utils.any_authenticated_user(request.headers):
-        return HTTPErrorTuple(HTTPStatus.UNAUTHORIZED,
-                              'User not authenticated').astuple()
+        return cors_response(HTTPStatus.UNAUTHORIZED,
+                             xerror='User not authenticated')
 
     return 'Method unimplemented', 400, {'X-Error': 'Method unimplemented'}


### PR DESCRIPTION
This adds the fix for #17 proposed in https://github.com/fabric-testbed/software-planning/issues/30, as well as adds the use of HTTPErrorTuple implemented here https://github.com/fabric-testbed/system-service-utils/pull/11.

Tested locally. The vouch/config_template already has `publicAccess: true`, so no updates to that, however when deploying on beta or production, need to make sure it is set to true, as prior to this it was set to false. Requires extensive testing in place on beta as I was only able to do some limited testing locally. 

