### PR TITLE
Attempting to fix issues with concurrent queries from bastion hosts; …

### DIFF
--- a/server/setup.py
+++ b/server/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import setup, find_packages
 
 NAME = "swagger_server"
-VERSION = "1.1.0"
+VERSION = "1.1.1"
 # To install the library, run the following
 #
 # python setup.py install

--- a/server/swagger_server/response_code/sshkey_controller.py
+++ b/server/swagger_server/response_code/sshkey_controller.py
@@ -95,7 +95,7 @@ class SshKeyShort:
 
 TZISO = r"^.+\+[\d]{2}:[\d]{2}$"
 TZPYTHON = r"^.+\+[\d]{4}$"
-DESCRIPTION_REGEX = r"^[\w\s\-\.@_()/]{5,255}$"
+DESCRIPTION_REGEX = r"^[\w\s\-'\.@_()/]{5,255}$"
 COMMENT_LENGTH = 100
 
 
@@ -111,76 +111,77 @@ def bastionkeys_get(secret, since_date) -> List[SshKeyBastion]:
         return cors_response(HTTPStatus.UNAUTHORIZED,
                              xerror='User not authorized')
     with Session() as session:
-        _update_keys(session)
+        with session.begin():
+            _update_keys(session)
 
-        # first a list of new keys
-        try:
-            since_date = since_date.strip()
-            # with +00:00
-            if re.match(TZISO, since_date) is not None:
-                pdate = datetime.fromisoformat(since_date)
-            # with +0000
-            elif re.match(TZPYTHON, since_date) is not None:
-                pdate = datetime.strptime(since_date, "%Y-%m-%d %H:%M:%S%z")
-            # perhaps no TZ info? add as if UTC
-            else:
-                pdate = datetime.strptime(since_date + "+0000", "%Y-%m-%d %H:%M:%S%z")
-            # convert to UTC
-            pdate = pdate.astimezone(timezone.utc)
-        except ValueError:
-            log.error(f'Unable to convert date {since_date}')
-            return cors_response(HTTPStatus.BAD_REQUEST,
-                                 xerror=f'Provided date {since_date} is invalid.')
-
-        log.info(f'Using time {pdate} to search for new or expired keys.')
-        ret = list()
-        query = session.query(DbSshKey, FabricPerson).filter(DbSshKey.active == True,
-                                                             DbSshKey.created_on > pdate,
-                                                             DbSshKey.fabric_key_type == KeyType.bastion.name,
-                                                             DbSshKey.owner_uuid == FabricPerson.uuid)
-        query_result = query.all()
-        for qk, qp in query_result:
+            # first a list of new keys
             try:
-                log.debug(f'Found new key created on {qk.created_on} for user {qp.bastion_login}')
-                k = SshKeyBastion()
-                k.status = KeyStatus.active.name
-                # for bastion update the comment to include expiration date/time
-                k.public_openssh = " ".join([qk.ssh_key_type, qk.public_key,
-                                             _make_bastion_comment(qk.comment, qk.expires_on)])
-                k.login = qp.bastion_login
-                # GECOS is a 5-field comma-separated field that includes things like full name
-                # various locations, phone numbers and emails. External email is part of the 5th field
-                k.gecos = get_gecos(qp)
-                ret.append(k)
-            except Exception:
-                log.error(f'Unable to report new bastion key starting with {qk.public_key[0:100]} '
-                          f'for user {qp.bastion_login}')
-                return cors_response(HTTPStatus.INTERNAL_SERVER_ERROR,
-                                     xerror='Unable to report bastion keys due to internal error.')
+                since_date = since_date.strip()
+                # with +00:00
+                if re.match(TZISO, since_date) is not None:
+                    pdate = datetime.fromisoformat(since_date)
+                # with +0000
+                elif re.match(TZPYTHON, since_date) is not None:
+                    pdate = datetime.strptime(since_date, "%Y-%m-%d %H:%M:%S%z")
+                # perhaps no TZ info? add as if UTC
+                else:
+                    pdate = datetime.strptime(since_date + "+0000", "%Y-%m-%d %H:%M:%S%z")
+                # convert to UTC
+                pdate = pdate.astimezone(timezone.utc)
+            except ValueError:
+                log.error(f'Unable to convert date {since_date}')
+                return cors_response(HTTPStatus.BAD_REQUEST,
+                                     xerror=f'Provided date {since_date} is invalid.')
 
-        query = session.query(DbSshKey, FabricPerson).filter(DbSshKey.active == False,
-                                                             DbSshKey.deactivated_on > pdate,
-                                                             DbSshKey.fabric_key_type == KeyType.bastion.name,
-                                                             DbSshKey.owner_uuid == FabricPerson.uuid)
-        query_result = query.all()
-        for qk, qp in query_result:
-            try:
-                log.debug(f'Found expired key deactivated on {qk.deactivated_on} for user {qp.bastion_login}')
-                k = SshKeyBastion()
-                k.status = KeyStatus.deactivated.name
-                # for bastion update the comment to include expiration date/time
-                k.public_openssh = " ".join([qk.ssh_key_type, qk.public_key,
-                                             _make_bastion_comment(qk.comment, qk.expires_on)])
-                k.login = qp.bastion_login
-                k.gecos = get_gecos(qp)
-                ret.append(k)
-            except Exception:
-                log.error(f'Unable to report expired bastion key starting with {qk.public_key[0:100]} '
-                          f'for user {qp.bastion_login}')
-                return cors_response(HTTPStatus.INTERNAL_SERVER_ERROR,
-                                     xerror='Unable to report bastion keys due to internal error.')
+            log.info(f'Using time {pdate} to search for new or expired keys.')
+            ret = list()
+            query = session.query(DbSshKey, FabricPerson).filter(DbSshKey.active == True,
+                                                                 DbSshKey.created_on > pdate,
+                                                                 DbSshKey.fabric_key_type == KeyType.bastion.name,
+                                                                 DbSshKey.owner_uuid == FabricPerson.uuid)
+            query_result = query.all()
+            for qk, qp in query_result:
+                try:
+                    log.debug(f'Found new key created on {qk.created_on} for user {qp.bastion_login}')
+                    k = SshKeyBastion()
+                    k.status = KeyStatus.active.name
+                    # for bastion update the comment to include expiration date/time
+                    k.public_openssh = " ".join([qk.ssh_key_type, qk.public_key,
+                                                 _make_bastion_comment(qk.comment, qk.expires_on)])
+                    k.login = qp.bastion_login
+                    # GECOS is a 5-field comma-separated field that includes things like full name
+                    # various locations, phone numbers and emails. External email is part of the 5th field
+                    k.gecos = get_gecos(qp)
+                    ret.append(k)
+                except Exception:
+                    log.error(f'Unable to report new bastion key starting with {qk.public_key[0:100]} '
+                              f'for user {qp.bastion_login}')
+                    return cors_response(HTTPStatus.INTERNAL_SERVER_ERROR,
+                                         xerror='Unable to report bastion keys due to internal error.')
 
-        return ret
+            query = session.query(DbSshKey, FabricPerson).filter(DbSshKey.active == False,
+                                                                 DbSshKey.deactivated_on > pdate,
+                                                                 DbSshKey.fabric_key_type == KeyType.bastion.name,
+                                                                 DbSshKey.owner_uuid == FabricPerson.uuid)
+            query_result = query.all()
+            for qk, qp in query_result:
+                try:
+                    log.debug(f'Found expired key deactivated on {qk.deactivated_on} for user {qp.bastion_login}')
+                    k = SshKeyBastion()
+                    k.status = KeyStatus.deactivated.name
+                    # for bastion update the comment to include expiration date/time
+                    k.public_openssh = " ".join([qk.ssh_key_type, qk.public_key,
+                                                 _make_bastion_comment(qk.comment, qk.expires_on)])
+                    k.login = qp.bastion_login
+                    k.gecos = get_gecos(qp)
+                    ret.append(k)
+                except Exception:
+                    log.error(f'Unable to report expired bastion key starting with {qk.public_key[0:100]} '
+                              f'for user {qp.bastion_login}')
+                    return cors_response(HTTPStatus.INTERNAL_SERVER_ERROR,
+                                         xerror='Unable to report bastion keys due to internal error.')
+
+            return ret
 
 
 def sshkeys_get() -> List[SshKeyLong]:  # noqa: E501
@@ -200,28 +201,29 @@ def sshkeys_get() -> List[SshKeyLong]:  # noqa: E501
                              xerror='Unable to find UUID from OIDC Sub claim')
 
     with Session() as session:
-        status, active_flag = utils.check_user_active(session, request.headers)
-        if status != 200:
-            log.error(f'Error {status} contacting COmanage in sshkeys_get')
-            return cors_response(HTTPStatus.INTERNAL_SERVER_ERROR,
-                                 xerror=f'Error {status} contacting COmanage')
+        with session.begin():
+            status, active_flag = utils.check_user_active(session, request.headers)
+            if status != 200:
+                log.error(f'Error {status} contacting COmanage in sshkeys_get')
+                return cors_response(HTTPStatus.INTERNAL_SERVER_ERROR,
+                                     xerror=f'Error {status} contacting COmanage')
 
-        if not active_flag:
-            log.warn(f'User is not an active user in sshkeys_get')
-            return cors_response(HTTPStatus.FORBIDDEN,
-                                 xerror='User not an active user')
+            if not active_flag:
+                log.warn(f'User is not an active user in sshkeys_get')
+                return cors_response(HTTPStatus.FORBIDDEN,
+                                     xerror='User not an active user')
 
-        _update_keys(session)
+            _update_keys(session)
 
-        query = session.query(DbSshKey).filter(DbSshKey.owner_uuid == _uuid,
-                                               DbSshKey.active == True)
-        query_result = query.all()
+            query = session.query(DbSshKey).filter(DbSshKey.owner_uuid == _uuid,
+                                                   DbSshKey.active == True)
+            query_result = query.all()
 
-        ret = list()
-        for res in query_result:
-            ret.append(_fill_long_key(res))
+            ret = list()
+            for res in query_result:
+                ret.append(_fill_long_key(res))
 
-        return ret
+            return ret
 
 
 def sshkeys_keyid_delete(keyid: str) -> str:  # noqa: E501
@@ -244,40 +246,41 @@ def sshkeys_keyid_delete(keyid: str) -> str:  # noqa: E501
         return cors_response(HTTPStatus.FORBIDDEN,
                              xerror='Unable to find UUID from OIDC Sub claim')
 
+    comanage_sliver_keys = list()
     with Session() as session:
-        status, active_flag = utils.check_user_active(session, request.headers)
-        if status != 200:
-            log.error(f'Error {status} contacting COmanage in sshkeys_keyid_delete')
-            return cors_response(HTTPStatus.INTERNAL_SERVER_ERROR,
-                                 xerror=f'Error {status} contacting COmanage')
+        with session.begin():
+            status, active_flag = utils.check_user_active(session, request.headers)
+            if status != 200:
+                log.error(f'Error {status} contacting COmanage in sshkeys_keyid_delete')
+                return cors_response(HTTPStatus.INTERNAL_SERVER_ERROR,
+                                     xerror=f'Error {status} contacting COmanage')
 
-        if not active_flag:
-            log.warn(f'User is not an active user in sshkeys_keyid_delete')
-            return cors_response(HTTPStatus.FORBIDDEN,
-                                 xerror='User not an active user')
-        _update_keys(session)
+            if not active_flag:
+                log.warn(f'User is not an active user in sshkeys_keyid_delete')
+                return cors_response(HTTPStatus.FORBIDDEN,
+                                     xerror='User not an active user')
+            _update_keys(session)
 
-        query = session.query(DbSshKey).filter(DbSshKey.owner_uuid == _uuid,
-                                               DbSshKey.key_uuid == keyid,
-                                               DbSshKey.active == True)
-        query_result = query.all()
-        if len(query_result) > 0:
-            for q in query_result:
-                q.active = False
-                q.deactivation_reason = f'Deactivated by owner on {datetime.now(timezone.utc)}Z'
-                q.deactivated_on = datetime.now(timezone.utc)
-                if SSH_SLIVER_KEY_TO_COMANAGE and q.fabric_key_type == KeyType.sliver.name:
-                    log.info(f'Removing deleted sliver key {q.comment}/{q.key_uuid} '
-                             f'for user {q.owner_uuid} from COmanage')
-                    try:
-                        co_api.ssh_keys_delete(q.comanage_key_id)
-                    except requests.HTTPError as e:
-                        log.error(
-                            f'Unable to delete expired sliver key {q.key_uuid}/{q.key_uuid} for user {q.owner_uuid} '
-                            f'from COmanage due to: {e}')
-        session.commit()
+            query = session.query(DbSshKey).filter(DbSshKey.owner_uuid == _uuid,
+                                                   DbSshKey.key_uuid == keyid,
+                                                   DbSshKey.active == True)
+            query_result = query.all()
+            if len(query_result) > 0:
+                for q in query_result:
+                    q.active = False
+                    q.deactivation_reason = f'Deactivated by owner on {datetime.now(timezone.utc)}Z'
+                    q.deactivated_on = datetime.now(timezone.utc)
+                    if SSH_SLIVER_KEY_TO_COMANAGE and q.fabric_key_type == KeyType.sliver.name:
+                        comanage_sliver_keys.append(q.comanage_key_id)
+            # automatically commits session here (with)
 
-        return "OK"
+    for ck in comanage_sliver_keys:
+        try:
+            co_api.ssh_keys_delete(ck)
+        except requests.HTTPError as e:
+            log.error(f'Unable to delete expired sliver key {ck} from COmanage due to: {e}')
+
+    return "OK"
 
 
 def sshkey_uuid_keyid_get(_uuid: str, keyid: str) -> SshKeyLong:  # noqa: E501
@@ -301,31 +304,32 @@ def sshkey_uuid_keyid_get(_uuid: str, keyid: str) -> SshKeyLong:  # noqa: E501
                              xerror='Supplied keyid {0} is not valid.'.format(keyid))
 
     with Session() as session:
-        status, active_flag = utils.check_user_active(session, request.headers)
-        if status != 200:
-            log.error(f'Error {status} contacting COmanage in sshkeys_uuid_keyid_get')
-            return cors_response(HTTPStatus.INTERNAL_SERVER_ERROR,
-                                 xerror=f'Error {status} contacting COmanage')
+        with session.begin():
+            status, active_flag = utils.check_user_active(session, request.headers)
+            if status != 200:
+                log.error(f'Error {status} contacting COmanage in sshkeys_uuid_keyid_get')
+                return cors_response(HTTPStatus.INTERNAL_SERVER_ERROR,
+                                     xerror=f'Error {status} contacting COmanage')
 
-        if not active_flag:
-            log.warn(f'User is not an active user in in sshkeys_uuid_keyid_get')
-            return cors_response(HTTPStatus.FORBIDDEN,
-                                 xerror='User not an active user')
+            if not active_flag:
+                log.warn(f'User is not an active user in in sshkeys_uuid_keyid_get')
+                return cors_response(HTTPStatus.FORBIDDEN,
+                                     xerror='User not an active user')
 
-        _update_keys(session)
+            _update_keys(session)
 
-        query = session.query(DbSshKey).filter(DbSshKey.owner_uuid == _uuid,
-                                               DbSshKey.active == True,
-                                               DbSshKey.key_uuid == keyid)
-        query_result = query.all()
+            query = session.query(DbSshKey).filter(DbSshKey.owner_uuid == _uuid,
+                                                   DbSshKey.active == True,
+                                                   DbSshKey.key_uuid == keyid)
+            query_result = query.all()
 
-        if len(query_result) < 1:
-            log.warn(f'Unable to find active key {keyid} for user {_uuid} in sshkeys_uuid_keyid_get, '
-                     f'proceeding')
-            return cors_response(HTTPStatus.NOT_FOUND,
-                                 xerror='Key {0} not found for user {1}'.format(keyid, _uuid))
+            if len(query_result) < 1:
+                log.warn(f'Unable to find active key {keyid} for user {_uuid} in sshkeys_uuid_keyid_get, '
+                         f'proceeding')
+                return cors_response(HTTPStatus.NOT_FOUND,
+                                     xerror='Key {0} not found for user {1}'.format(keyid, _uuid))
 
-        return _fill_long_key(query_result[0])
+            return _fill_long_key(query_result[0])
 
 
 def sshkey_keyid_get(keyid: str) -> SshKeyLong:  # noqa: E501
@@ -349,30 +353,31 @@ def sshkey_keyid_get(keyid: str) -> SshKeyLong:  # noqa: E501
                              xerror='Unable to find UUID from OIDC Sub claim')
 
     with Session() as session:
-        status, active_flag = utils.check_user_active(session, request.headers)
-        if status != 200:
-            log.error(f'Error {status} contacting COmanage in sshkeys_keyid_get')
-            return cors_response(HTTPStatus.INTERNAL_SERVER_ERROR,
-                                 xerror=f'Error {status} contacting COmanage')
+        with session.begin():
+            status, active_flag = utils.check_user_active(session, request.headers)
+            if status != 200:
+                log.error(f'Error {status} contacting COmanage in sshkeys_keyid_get')
+                return cors_response(HTTPStatus.INTERNAL_SERVER_ERROR,
+                                     xerror=f'Error {status} contacting COmanage')
 
-        if not active_flag:
-            log.warn(f'User is not an active user in sshkeys_keyid_get')
-            return cors_response(HTTPStatus.FORBIDDEN,
-                                 xerror='User not an active user')
+            if not active_flag:
+                log.warn(f'User is not an active user in sshkeys_keyid_get')
+                return cors_response(HTTPStatus.FORBIDDEN,
+                                     xerror='User not an active user')
 
-        _update_keys(session)
+            _update_keys(session)
 
-        query = session.query(DbSshKey).filter(DbSshKey.owner_uuid == _uuid,
-                                               DbSshKey.key_uuid == keyid)
-        query_result = query.all()
+            query = session.query(DbSshKey).filter(DbSshKey.owner_uuid == _uuid,
+                                                   DbSshKey.key_uuid == keyid)
+            query_result = query.all()
 
-        if len(query_result) < 1:
-            log.warn(f'Unable to find key {keyid} for user {_uuid} in sshkeys_keyid_get, '
-                     f'proceeding')
-            return cors_response(HTTPStatus.NOT_FOUND,
-                                 xerror='Key {0} not found for user {1}'.format(keyid, _uuid))
+            if len(query_result) < 1:
+                log.warn(f'Unable to find key {keyid} for user {_uuid} in sshkeys_keyid_get, '
+                         f'proceeding')
+                return cors_response(HTTPStatus.NOT_FOUND,
+                                     xerror='Key {0} not found for user {1}'.format(keyid, _uuid))
 
-        return _fill_long_key(query_result[0])
+            return _fill_long_key(query_result[0])
 
 
 def sshkeys_keytype_post(keytype: str, public_openssh: str, description: str) -> str:  # noqa: E501
@@ -391,49 +396,50 @@ def sshkeys_keytype_post(keytype: str, public_openssh: str, description: str) ->
                              xerror='Unable to find UUID from OIDC Sub claim')
 
     with Session() as session:
-        # checks are in this order on purpose so we do the cheapest checks first
+        with session.begin():
+            # checks are in this order on purpose so we do the cheapest checks first
 
-        if _check_key_qty(_uuid, keytype, session) >= SSH_KEY_QTY_LIMIT:
-            log.error(f'Too many keys of type {keytype} for user {_uuid}, limit {SSH_KEY_QTY_LIMIT}')
-            return cors_response(HTTPStatus.BAD_REQUEST,
-                                 xerror=f'Too many active keys for this user, limit {SSH_KEY_QTY_LIMIT}')
+            if _check_key_qty(_uuid, keytype, session) >= SSH_KEY_QTY_LIMIT:
+                log.error(f'Too many keys of type {keytype} for user {_uuid}, limit {SSH_KEY_QTY_LIMIT}')
+                return cors_response(HTTPStatus.BAD_REQUEST,
+                                     xerror=f'Too many active keys for this user, limit {SSH_KEY_QTY_LIMIT}')
 
-        status, active_flag = utils.check_user_active(session, request.headers)
-        if status != 200:
-            log.error(f'Error {status} contacting COmanage in sshkeys_keytype_post')
-            return cors_response(HTTPStatus.INTERNAL_SERVER_ERROR,
-                                 xerror=f'Error {status} contacting COmanage')
+            status, active_flag = utils.check_user_active(session, request.headers)
+            if status != 200:
+                log.error(f'Error {status} contacting COmanage in sshkeys_keytype_post')
+                return cors_response(HTTPStatus.INTERNAL_SERVER_ERROR,
+                                     xerror=f'Error {status} contacting COmanage')
 
-        if not active_flag:
-            log.warn(f'User is not an active user in sshkeys_keytype_post')
-            return cors_response(HTTPStatus.FORBIDDEN,
-                                 xerror='User not an active user')
+            if not active_flag:
+                log.warn(f'User is not an active user in sshkeys_keytype_post')
+                return cors_response(HTTPStatus.FORBIDDEN,
+                                     xerror='User not an active user')
 
-        # instantiate to test its validity
-        try:
-            fssh = FABRICSSHKey(public_openssh)
-        except FABRICSSHKeyException as e:
-            log.error(f'Provided key for {_uuid} is invalid due to {str(e)}')
-            return cors_response(HTTPStatus.BAD_REQUEST,
-                                 xerror=f'Provided key for {_uuid} is invalid due to {str(e)}')
+            # instantiate to test its validity
+            try:
+                fssh = FABRICSSHKey(public_openssh)
+            except FABRICSSHKeyException as e:
+                log.error(f'Provided key for {_uuid} is invalid due to {str(e)}')
+                return cors_response(HTTPStatus.BAD_REQUEST,
+                                     xerror=f'Provided key for {_uuid} is invalid due to {str(e)}')
 
-        if not _check_unique(_uuid, fssh.get_fingerprint(), session):
-            log.error(f'Provided key for {_uuid} with fingerprint {fssh.get_fingerprint()} is not unique')
-            return cors_response(HTTPStatus.BAD_REQUEST,
-                                 xerror=f'Provided key for {_uuid} with fingerprint '
-                                        f'{fssh.get_fingerprint()} is not unique')
+            if not _check_unique(_uuid, fssh.get_fingerprint(), session):
+                log.error(f'Provided key for {_uuid} with fingerprint {fssh.get_fingerprint()} is not unique')
+                return cors_response(HTTPStatus.BAD_REQUEST,
+                                     xerror=f'Provided key for {_uuid} with fingerprint '
+                                            f'{fssh.get_fingerprint()} is not unique')
 
-        short_key = SshKeyShort()
-        short_key.ssh_key_type = fssh.name
-        short_key.comment = fssh.comment
-        short_key.public_key = fssh.public_key
-        short_key.fingerprint = fssh.get_fingerprint()
-        matches = re.match(DESCRIPTION_REGEX, description)
-        if matches is None:
-            log.error(f'Provided description for {_uuid} does not match expected REGEX {DESCRIPTION_REGEX}')
-            return cors_response(HTTPStatus.BAD_REQUEST,
-                                 xerror=f'Provided description does not match expected REGEX {DESCRIPTION_REGEX}')
-        short_key.description = description
+            short_key = SshKeyShort()
+            short_key.ssh_key_type = fssh.name
+            short_key.comment = fssh.comment
+            short_key.public_key = fssh.public_key
+            short_key.fingerprint = fssh.get_fingerprint()
+            matches = re.match(DESCRIPTION_REGEX, description)
+            if matches is None:
+                log.error(f'Provided description for {_uuid} does not match expected REGEX {DESCRIPTION_REGEX}')
+                return cors_response(HTTPStatus.BAD_REQUEST,
+                                     xerror=f'Provided description does not match expected REGEX {DESCRIPTION_REGEX}')
+            short_key.description = description
 
     _store_ssh_key(_uuid, keytype, short_key)
 
@@ -456,16 +462,22 @@ def sshkeys_keytype_put(keytype: str, comment: str, description: str) -> SshKeyP
                              xerror='Unable to find UUID from OIDC Sub claim')
 
     with Session() as session:
-        status, active_flag = utils.check_user_active(session, request.headers)
-        if status != 200:
-            log.error(f'Error {status} contacting COmanage in sshkeys_keytype_put')
-            return cors_response(HTTPStatus.INTERNAL_SERVER_ERROR,
-                                 xerror=f'Error {status} contacting COmanage')
+        with session.begin():
+            if _check_key_qty(_uuid, keytype, session) >= SSH_KEY_QTY_LIMIT:
+                log.error(f'Too many keys of type {keytype} for user {_uuid}, limit {SSH_KEY_QTY_LIMIT}')
+                return cors_response(HTTPStatus.BAD_REQUEST,
+                                     xerror=f'Too many active keys for this user, limit {SSH_KEY_QTY_LIMIT}')
 
-        if not active_flag:
-            log.warn(f'User is not an active user in sshkeys_keytype_put')
-            return cors_response(HTTPStatus.FORBIDDEN,
-                                 xerror='User not an active user')
+            status, active_flag = utils.check_user_active(session, request.headers)
+            if status != 200:
+                log.error(f'Error {status} contacting COmanage in sshkeys_keytype_put')
+                return cors_response(HTTPStatus.INTERNAL_SERVER_ERROR,
+                                     xerror=f'Error {status} contacting COmanage')
+
+            if not active_flag:
+                log.warn(f'User is not an active user in sshkeys_keytype_put')
+                return cors_response(HTTPStatus.FORBIDDEN,
+                                     xerror='User not an active user')
 
     log.info(f'Generating key of type {keytype} for {_uuid} with comment {comment}')
     try:
@@ -500,15 +512,13 @@ def _update_keys(session):
     Make an atomic update - expire keys, then garbage collect
     """
 
-    session.begin_nested()
+    #with session.begin_nested():
     # https://stackoverflow.com/questions/37331646/sqlalchemy-explicit-locking-of-postgresql-table
-    session.execute('LOCK TABLE fabric_sshkeys IN ACCESS EXCLUSIVE MODE;')
+    #session.execute('LOCK TABLE fabric_sshkeys IN ACCESS EXCLUSIVE MODE;')
+    #with session.begin_nested():
     _expire_keys(session)
-    session.flush()
     _garbage_collect_keys(session)
-    session.commit()
-    # close nested transaction and unlock table
-    session.commit()
+    #session.flush()
 
 
 def _expire_keys(session):
@@ -537,7 +547,7 @@ def _garbage_collect_keys(session):
     Delete deactivated keys older than specified period (from db and COmanage)
     """
     now = datetime.now(timezone.utc)
-    gc_delta = timedelta(days=SSH_GARBAGE_COLLECT_AFTER_DAYS)
+    gc_delta = timedelta(minutes=SSH_GARBAGE_COLLECT_AFTER_DAYS)
     check_instant = now - gc_delta
     session.query(DbSshKey).\
         filter(DbSshKey.deactivated_on < check_instant,
@@ -576,9 +586,9 @@ def _store_ssh_key(_uuid: str, keytype: str, key: SshKeyShort) -> None:
     db_key.public_key = key.public_key
     db_key.created_on = datetime.now(timezone.utc)
     if keytype == KeyType.sliver.name:
-        exp_delta = timedelta(days=SSH_SLIVER_KEY_VALIDITY_DAYS)
+        exp_delta = timedelta(minutes=SSH_SLIVER_KEY_VALIDITY_DAYS)
     else:
-        exp_delta = timedelta(days=SSH_BASTION_KEY_VALIDITY_DAYS)
+        exp_delta = timedelta(minutes=SSH_BASTION_KEY_VALIDITY_DAYS)
     db_key.expires_on = db_key.created_on + exp_delta
     db_key.active = True
     db_key.fingerprint = key.fingerprint
@@ -586,45 +596,46 @@ def _store_ssh_key(_uuid: str, keytype: str, key: SshKeyShort) -> None:
     db_key.fabric_key_type = keytype
 
     with Session() as session:
-        # did we want to store copy of sliver key in COmanage?
-        if SSH_SLIVER_KEY_TO_COMANAGE and keytype == KeyType.sliver.name:
-            log.debug(f'Storing sliver key {db_key.comment} for user {_uuid} in COmanage')
-            query = session.query(FabricPerson).filter(FabricPerson.uuid == _uuid)
-            query_result = query.all()
-            if len(query_result) == 0:
-                log.error(f'Unable to store key {db_key.comment} for user {_uuid} in COmanage'
-                          f' - unable to find them in database')
-            else:
-                co_key_response = None
-                try:
-                    person = query_result[0]
-                    co_person_id = person.co_person_id
-                    if co_person_id is None:
-                        log.info(f'Looking up co_person_id in _store_ssh_key for person {person.uuid}')
-                        # we already know they are active
-                        _, _, co_person_id = utils.comanage_check_active_person(person)
+        with session.begin():
+            # did we want to store copy of sliver key in COmanage?
+            if SSH_SLIVER_KEY_TO_COMANAGE and keytype == KeyType.sliver.name:
+                log.debug(f'Storing sliver key {db_key.comment} for user {_uuid} in COmanage')
+                query = session.query(FabricPerson).filter(FabricPerson.uuid == _uuid)
+                query_result = query.all()
+                if len(query_result) == 0:
+                    log.error(f'Unable to store key {db_key.comment} for user {_uuid} in COmanage'
+                              f' - unable to find them in database')
+                else:
+                    co_key_response = None
+                    try:
+                        person = query_result[0]
+                        co_person_id = person.co_person_id
+                        if co_person_id is None:
+                            log.info(f'Looking up co_person_id in _store_ssh_key for person {person.uuid}')
+                            # we already know they are active
+                            _, _, co_person_id = utils.comanage_check_active_person(person)
 
-                    if co_person_id is not None:
-                        # update the person table in database with co_person_id while we're at it
-                        setattr(person, 'co_person_id', co_person_id)
-                        log.debug(f'Adding sliver key {db_key.comment} for user {_uuid}/{co_person_id} '
-                                  f'to COmanage [ {key.public_key=}, {key.ssh_key_type=}, {key.comment=}')
-                        co_key_response = co_api.ssh_keys_add(query_result[0].co_person_id,
-                                                              key.public_key, key.ssh_key_type, key.comment)
-                    else:
-                        log.warn(f'Unable to add sliver key {db_key.comment} for user '
-                                 f'{_uuid} due to missing co_person_id')
-                except requests.HTTPError as e:
-                    log.error(f'Unable to add sliver key {db_key.comment} for user {_uuid} to COmanage due to {e}')
-                if co_key_response:
-                    if co_key_response.get('Id', None) is None:
-                        log.error(f'Unable to add sliver key {db_key.comment} for user '
-                                  f'{_uuid} due to unexpected return format of the response: {co_key_response=}')
-                    else:
-                        db_key.comanage_key_id = co_key_response['Id']
+                        if co_person_id is not None:
+                            # update the person table in database with co_person_id while we're at it
+                            setattr(person, 'co_person_id', co_person_id)
+                            log.debug(f'Adding sliver key {db_key.comment} for user {_uuid}/{co_person_id} '
+                                      f'to COmanage [ {key.public_key=}, {key.ssh_key_type=}, {key.comment=}')
+                            co_key_response = co_api.ssh_keys_add(query_result[0].co_person_id,
+                                                                  key.public_key, key.ssh_key_type, key.comment)
+                        else:
+                            log.warn(f'Unable to add sliver key {db_key.comment} for user '
+                                     f'{_uuid} due to missing co_person_id')
+                    except requests.HTTPError as e:
+                        log.error(f'Unable to add sliver key {db_key.comment} for user {_uuid} to COmanage due to {e}')
+                    if co_key_response:
+                        if co_key_response.get('Id', None) is None:
+                            log.error(f'Unable to add sliver key {db_key.comment} for user '
+                                      f'{_uuid} due to unexpected return format of the response: {co_key_response=}')
+                        else:
+                            db_key.comanage_key_id = co_key_response['Id']
 
-        session.add(db_key)
-        session.commit()
+            session.add(db_key)
+            # commits automatically
 
 
 def _check_key_qty(_uuid: str, keytype: str, session: Session) -> int:


### PR DESCRIPTION
…surrounded all transactions with begin() statements; still seeing some errors, see below. 

This code removes table locking that was likely a cause of uWSGI errors. 

This also fixes a bug of not counting generated bastion keys (previous version only counted uploaded bastion keys).

The error that happens now is some kind of a conflict between two transactions in different threads - one for bastion get and another for key generation. To reproduce use client-hammer script from bastion key script repo and while it is running (set `-t` 1000 or more) generate keys using PUT call on UIS. The errors that pop up are of this sort:

https://github.com/psycopg/psycopg2/issues/281

Typically from two separate sessions (one from key creation, one from querying bastion keys). Errors don't always happen during a run - some race condition. These errors do not result in a wrong server state - a user can continue generating keys afterwards and no inconsistent state is created. 

```
uis-database     | 2022-02-07 04:50:05.560 UTC [143] WARNING:  there is already a transaction in progress
uis-server       | ERROR:swagger_server:Exception on /sshkey/bastion [PUT]
uis-server       | Traceback (most recent call last):
uis-server       |   File "/code/venv/lib/python3.9/site-packages/flask/app.py", line 2447, in wsgi_app
uis-server       |     response = self.full_dispatch_request()
uis-server       |   File "/code/venv/lib/python3.9/site-packages/flask/app.py", line 1952, in full_dispatch_request
uis-server       |     rv = self.handle_user_exception(e)
uis-server       |   File "/code/venv/lib/python3.9/site-packages/flask/app.py", line 1821, in handle_user_exception
uis-server       |     reraise(exc_type, exc_value, tb)
uis-server       |   File "/code/venv/lib/python3.9/site-packages/flask/_compat.py", line 39, in reraise
uis-server       |     raise value
uis-server       |   File "/code/venv/lib/python3.9/site-packages/flask/app.py", line 1950, in full_dispatch_request
uis-server       |     rv = self.dispatch_request()
uis-server       |   File "/code/venv/lib/python3.9/site-packages/flask/app.py", line 1936, in dispatch_request
uis-server       |     return self.view_functions[rule.endpoint](**req.view_args)
uis-server       |   File "/code/venv/lib/python3.9/site-packages/connexion/decorators/decorator.py", line 48, in wrapper
uis-server       |     response = function(request)
uis-server       |   File "/code/venv/lib/python3.9/site-packages/connexion/decorators/uri_parsing.py", line 144, in wrapper
uis-server       |     response = function(request)
uis-server       |   File "/code/venv/lib/python3.9/site-packages/connexion/decorators/validation.py", line 384, in wrapper
uis-server       |     return function(request)
uis-server       |   File "/code/venv/lib/python3.9/site-packages/connexion/decorators/parameter.py", line 121, in wrapper
uis-server       |     return function(**kwargs)
uis-server       |   File "./swagger_server/controllers/sshkeys_controller.py", line 87, in sshkey_keytype_put
uis-server       |     return sc.sshkeys_keytype_put(keytype, comment, description)
uis-server       |   File "./swagger_server/response_code/sshkey_controller.py", line 466, in sshkeys_keytype_put
uis-server       |     if _check_key_qty(_uuid, keytype, session) >= SSH_KEY_QTY_LIMIT:
uis-server       |   File "./swagger_server/response_code/sshkey_controller.py", line 648, in _check_key_qty
uis-server       |     query_result = query.all()
uis-server       |   File "/code/venv/lib/python3.9/site-packages/sqlalchemy/orm/query.py", line 2759, in all
uis-server       |     return self._iter().all()
uis-server       |   File "/code/venv/lib/python3.9/site-packages/sqlalchemy/engine/result.py", line 1361, in all
uis-server       |     return self._allrows()
uis-server       |   File "/code/venv/lib/python3.9/site-packages/sqlalchemy/engine/result.py", line 400, in _allrows
uis-server       |     rows = self._fetchall_impl()
uis-server       |   File "/code/venv/lib/python3.9/site-packages/sqlalchemy/engine/result.py", line 1274, in _fetchall_impl
uis-server       |     return self._real_result._fetchall_impl()
uis-server       |   File "/code/venv/lib/python3.9/site-packages/sqlalchemy/engine/result.py", line 1686, in _fetchall_impl
uis-server       |     return list(self.iterator)
uis-server       |   File "/code/venv/lib/python3.9/site-packages/sqlalchemy/orm/loading.py", line 147, in chunks
uis-server       |     fetch = cursor._raw_all_rows()
uis-server       |   File "/code/venv/lib/python3.9/site-packages/sqlalchemy/engine/result.py", line 390, in _raw_all_rows
uis-server       |     make_row = self._row_getter
uis-server       |   File "/code/venv/lib/python3.9/site-packages/sqlalchemy/util/langhelpers.py", line 1180, in __get__
uis-server       |     obj.__dict__[self.__name__] = result = self.fget(obj)
uis-server       |   File "/code/venv/lib/python3.9/site-packages/sqlalchemy/engine/result.py", line 319, in _row_getter
uis-server       |     keymap = metadata._keymap
uis-server       |   File "/code/venv/lib/python3.9/site-packages/sqlalchemy/engine/cursor.py", line 1208, in _keymap
uis-server       |     self._we_dont_return_rows()
uis-server       |   File "/code/venv/lib/python3.9/site-packages/sqlalchemy/engine/cursor.py", line 1189, in _we_dont_return_rows
uis-server       |     util.raise_(
uis-server       |   File "/code/venv/lib/python3.9/site-packages/sqlalchemy/util/compat.py", line 207, in raise_
uis-server       |     raise exception
uis-nginx        | 172.20.0.1 - - [07/Feb/2022:04:50:05 +0000] "PUT /sshkey/bastion?comment=bkey1&description=bastion%20key%201 HTTP/2.0" 500 251 "https://127.0.0.1:8443/ui/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:96.0) Gecko/20100101 Firefox/96.0" "-"
uis-server       | sqlalchemy.exc.ResourceClosedError: This result object does not return rows. It has been closed automatically.
uis-server       | DEBUG:connexion.apis.abstract:Getting data and status code
uis-server       | DEBUG:connexion.apis.abstract:Prepared body and status code (500)
uis-server       | DEBUG:connexion.apis.abstract:Got framework response
uis-server       | [pid: 683|app: 0|req: 64/133] 172.20.0.4 () {54 vars in 3754 bytes} [Mon Feb  7 04:50:05 2022] PUT /sshkey/bastion?comment=bkey1&description=bastion%20key%201 => generated 251 bytes in 13 msecs (HTTP/1.0 500) 2 headers in 99 bytes (1 switches on core 1)
uis-server       | ERROR:swagger_server:Exception on /bastionkeys [GET]
uis-server       | Traceback (most recent call last):
uis-server       |   File "/code/venv/lib/python3.9/site-packages/sqlalchemy/engine/base.py", line 1802, in _execute_context
uis-server       |     self.dialect.do_execute(
uis-server       |   File "/code/venv/lib/python3.9/site-packages/sqlalchemy/engine/default.py", line 719, in do_execute
uis-server       |     cursor.execute(statement, parameters)
uis-server       | psycopg2.DatabaseError: error with status PGRES_TUPLES_OK and no message from the libpq
uis-server       | 
uis-server       | The above exception was the direct cause of the following exception:
uis-server       | 
uis-server       | Traceback (most recent call last):
uis-server       |   File "/code/venv/lib/python3.9/site-packages/flask/app.py", line 2447, in wsgi_app
uis-server       |     response = self.full_dispatch_request()
uis-server       |   File "/code/venv/lib/python3.9/site-packages/flask/app.py", line 1952, in full_dispatch_request
uis-server       |     rv = self.handle_user_exception(e)
uis-server       |   File "/code/venv/lib/python3.9/site-packages/flask/app.py", line 1821, in handle_user_exception
uis-server       |     reraise(exc_type, exc_value, tb)
uis-server       |   File "/code/venv/lib/python3.9/site-packages/flask/_compat.py", line 39, in reraise
uis-server       |     raise value
uis-server       |   File "/code/venv/lib/python3.9/site-packages/flask/app.py", line 1950, in full_dispatch_request
uis-server       |     rv = self.dispatch_request()
uis-server       |   File "/code/venv/lib/python3.9/site-packages/flask/app.py", line 1936, in dispatch_request
uis-server       |     return self.view_functions[rule.endpoint](**req.view_args)
uis-server       |   File "/code/venv/lib/python3.9/site-packages/connexion/decorators/decorator.py", line 48, in wrapper
uis-server       |     response = function(request)
uis-server       |   File "/code/venv/lib/python3.9/site-packages/connexion/decorators/uri_parsing.py", line 144, in wrapper
uis-server       |     response = function(request)
uis-server       |   File "/code/venv/lib/python3.9/site-packages/connexion/decorators/validation.py", line 384, in wrapper
uis-server       |     return function(request)
uis-server       |   File "/code/venv/lib/python3.9/site-packages/connexion/decorators/parameter.py", line 121, in wrapper
uis-server       |     return function(**kwargs)
uis-server       |   File "./swagger_server/controllers/sshkeys_controller.py", line 23, in bastionkeys_get
uis-server       |     return sc.bastionkeys_get(secret, since_date)
uis-server       |   File "./swagger_server/response_code/sshkey_controller.py", line 115, in bastionkeys_get
uis-server       |     _update_keys(session)
uis-server       |   File "./swagger_server/response_code/sshkey_controller.py", line 519, in _update_keys
uis-server       |     _expire_keys(session)
uis-server       |   File "./swagger_server/response_code/sshkey_controller.py", line 530, in _expire_keys
uis-server       |     query_result = query.all()
uis-server       |   File "/code/venv/lib/python3.9/site-packages/sqlalchemy/orm/query.py", line 2759, in all
uis-server       |     return self._iter().all()
uis-server       |   File "/code/venv/lib/python3.9/site-packages/sqlalchemy/orm/query.py", line 2894, in _iter
uis-server       |     result = self.session.execute(
uis-server       |   File "/code/venv/lib/python3.9/site-packages/sqlalchemy/orm/session.py", line 1689, in execute
uis-server       |     result = conn._execute_20(statement, params or {}, execution_options)
uis-server       |   File "/code/venv/lib/python3.9/site-packages/sqlalchemy/engine/base.py", line 1614, in _execute_20
uis-server       |     return meth(self, args_10style, kwargs_10style, execution_options)
uis-server       |   File "/code/venv/lib/python3.9/site-packages/sqlalchemy/sql/elements.py", line 325, in _execute_on_connection
uis-server       |     return connection._execute_clauseelement(
uis-server       |   File "/code/venv/lib/python3.9/site-packages/sqlalchemy/engine/base.py", line 1481, in _execute_clauseelement
uis-server       |     ret = self._execute_context(
uis-server       |   File "/code/venv/lib/python3.9/site-packages/sqlalchemy/engine/base.py", line 1845, in _execute_context
uis-server       |     self._handle_dbapi_exception(
uis-server       |   File "/code/venv/lib/python3.9/site-packages/sqlalchemy/engine/base.py", line 2026, in _handle_dbapi_exception
uis-server       |     util.raise_(
uis-server       |   File "/code/venv/lib/python3.9/site-packages/sqlalchemy/util/compat.py", line 207, in raise_
uis-server       |     raise exception
uis-server       |   File "/code/venv/lib/python3.9/site-packages/sqlalchemy/engine/base.py", line 1802, in _execute_context
uis-server       |     self.dialect.do_execute(
uis-server       |   File "/code/venv/lib/python3.9/site-packages/sqlalchemy/engine/default.py", line 719, in do_execute
uis-server       |     cursor.execute(statement, parameters)
uis-server       | sqlalchemy.exc.DatabaseError: (psycopg2.DatabaseError) error with status PGRES_TUPLES_OK and no message from the libpq
uis-server       | [SQL: SELECT fabric_sshkeys.id AS fabric_sshkeys_id, fabric_sshkeys.key_uuid AS fabric_sshkeys_key_uuid, fabric_sshkeys.comment AS fabric_sshkeys_comment, fabric_sshkeys.description AS fabric_sshkeys_description, fabric_sshkeys.ssh_key_type AS fabric_sshkeys_ssh_key_type, fabric_sshkeys.fabric_key_type AS fabric_sshkeys_fabric_key_type, fabric_sshkeys.fingerprint AS fabric_sshkeys_fingerprint, fabric_sshkeys.created_on AS fabric_sshkeys_created_on, fabric_sshkeys.expires_on AS fabric_sshkeys_expires_on, fabric_sshkeys.active AS fabric_sshkeys_active, fabric_sshkeys.deactivation_reason AS fabric_sshkeys_deactivation_reason, fabric_sshkeys.deactivated_on AS fabric_sshkeys_deactivated_on, fabric_sshkeys.owner_uuid AS fabric_sshkeys_owner_uuid, fabric_sshkeys.public_key AS fabric_sshkeys_public_key, fabric_sshkeys.comanage_key_id AS fabric_sshkeys_comanage_key_id 
uis-server       | FROM fabric_sshkeys 
uis-server       | WHERE fabric_sshkeys.expires_on < %(expires_on_1)s AND fabric_sshkeys.active = true]
uis-server       | [parameters: {'expires_on_1': datetime.datetime(2022, 2, 7, 4, 50, 5, 559661, tzinfo=datetime.timezone.utc)}]
uis-server       | (Background on this error at: https://sqlalche.me/e/14/4xp6)
uis-server       | DEBUG:connexion.apis.abstract:Getting data and status code
uis-server       | DEBUG:connexion.apis.abstract:Prepared body and status code (500)
```